### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Build Status](https://travis-ci.org/exoframejs/exoframe-server.svg?branch=master)](https://travis-ci.org/exoframejs/exoframe-server)
 [![Coverage Status](https://coveralls.io/repos/github/exoframejs/exoframe-server/badge.svg?branch=master)](https://coveralls.io/github/exoframejs/exoframe-server?branch=master)
-[![Docker Pulls](https://img.shields.io/docker/pulls/exoframe/server.svg?maxAge=2592000)](https://hub.docker.com/r/exoframe/server/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/exoframe/server.svg?maxAge=2592000)](https://hub.docker.com/r/exoframe/server/) [![](https://images.microbadger.com/badges/image/exoframe/server.svg)](https://microbadger.com/images/exoframe/server "Get your own image badge on microbadger.com")
 [![license](https://img.shields.io/github/license/mashape/apistatus.svg?maxAge=2592000)](https://opensource.org/licenses/MIT)
 
 [![asciicast](https://asciinema.org/a/85060.png)](https://asciinema.org/a/85060)
@@ -63,3 +63,4 @@ Now can point your Exoframe CLI to `http://localhost:3000` and use it.
 ## License
 
 Licensed under MIT.
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [exoframe/server](https://hub.docker.com/r/exoframe/server/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/exoframe/server).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/exoframe/server.svg)](https://microbadger.com/images/exoframe/server)
