### PR TITLE
Adding support for additional docker labels.

### DIFF
--- a/src/docker/start.js
+++ b/src/docker/start.js
@@ -38,6 +38,7 @@ module.exports = async ({image, username, resultStream}) => {
     RestartPolicy.Name = 'on-failure';
     RestartPolicy.MaximumRetryCount = restartCount;
   }
+  const additionalLabels = config.labels || {};
 
   // create config
   const containerConfig = {
@@ -45,6 +46,7 @@ module.exports = async ({image, username, resultStream}) => {
     name,
     Env,
     Labels: {
+      ...additionalLabels,
       'exoframe.deployment': name,
       'exoframe.user': username,
       'exoframe.project': project,

--- a/test/deploy.js
+++ b/test/deploy.js
@@ -503,13 +503,16 @@ module.exports = (server, token) =>
         // check response
         t.equal(response.statusCode, 200, 'Correct status code');
 
-
-
         // check docker services
         const allContainers = await docker.listContainers();
         const containerInfo = allContainers.find(c => c.Names.includes(deployments[0].Name));
         t.ok(containerInfo, 'Docker has container');
         t.equal(containerInfo.Labels['custom.label'], "additional-label", 'Should have label `custom.label=additional-label`');
+
+        // cleanup
+        const instance = docker.getContainer(containerInfo.Id);
+        await instance.stop();
+        await instance.remove();
         
         t.end();
       });

--- a/test/fixtures/additional-labels/exoframe.json
+++ b/test/fixtures/additional-labels/exoframe.json
@@ -1,0 +1,9 @@
+{
+  "name": "test-additional-labels",
+  "domain": false,
+  "project": "simple-html",
+  "restart": "no",
+  "labels": {
+    "custom.label" : "additional-label"
+  }
+}

--- a/test/fixtures/additional-labels/index.html
+++ b/test/fixtures/additional-labels/index.html
@@ -1,0 +1,8 @@
+<html lang="en">
+<head>
+    <title>hello world.</title>
+</head>
+<body>
+    <h1>Testing additional labels</h1>
+</body>
+</html>


### PR DESCRIPTION
Implemented my request from exoframejs/exoframe#85. Despite the suggestion of adding it as an array of strings I implemented it using an object like it is used in the node api. 

Tests are failing because I added another deployment. Maybe the current test should be integrated into the simple html deploy test. I did not want to change all the tests without first discussing this.
 