### PR TITLE
Add restart config to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ docker run -d \
   -e EXO_PRIVATE_KEY=your_private_key \
   --label traefik.backend=exoframe-server \
   --label traefik.frontend.rule=Host:exoframe.your-host.com \
+  --restart always \
   --name exoframe-server \
   exoframe/server
 


### PR DESCRIPTION
Adds a restart policy to the default run command, this lets exoframe restart after the server reboots which should be the default behavior. 