### PR TITLE
Updated docker labels. Fixes exoframejs/exoframe/issues/151

### DIFF
--- a/src/docker/start.js
+++ b/src/docker/start.js
@@ -64,6 +64,7 @@ exports.startFromParams = async ({
     'exoframe.project': projectName,
     'traefik.backend': backend,
     'traefik.docker.network': serverConfig.swarm ? serverConfig.exoframeNetworkSwarm : serverConfig.exoframeNetwork,
+    'traefik.enable': 'true',
   });
 
   // if host is set - add it to config
@@ -230,6 +231,8 @@ exports.start = async ({image, username, resultStream, existing = []}) => {
     'exoframe.user': username,
     'exoframe.project': project,
     'traefik.backend': backend,
+    'traefik.docker.network': serverConfig.swarm ? serverConfig.exoframeNetworkSwarm : serverConfig.exoframeNetwork,
+    'traefik.enable': 'true',
   });
 
   // if host is set - add it to config

--- a/src/docker/templates/compose.js
+++ b/src/docker/templates/compose.js
@@ -67,6 +67,7 @@ const updateCompose = ({username, baseName, serverConfig, composePath, util, res
       'traefik.port': '80',
       'traefik.backend': backend,
       'traefik.docker.network': network,
+      'traefik.enable': 'true',
     };
     if (serverConfig.swarm) {
       if (!compose.services[svcKey].deploy) {

--- a/test/deploy.swarm.test.js
+++ b/test/deploy.swarm.test.js
@@ -29,6 +29,9 @@ const streamBrokenNode = tar.pack(path.join(__dirname, 'fixtures', 'broken-node-
 const streamAdditionalLabels = tar.pack(path.join(__dirname, 'fixtures', 'additional-labels'));
 const streamTemplate = tar.pack(path.join(__dirname, 'fixtures', 'template-project'));
 
+// mock config
+const mockConfig = config.getConfig();
+
 // options base
 const optionsBase = {
   method: 'POST',
@@ -101,6 +104,8 @@ test('Should deploy simple docker project to swarm', async done => {
   expect(serviceInfo.Spec.Labels['exoframe.user']).toEqual('admin');
   expect(serviceInfo.Spec.Labels['exoframe.project']).toEqual('test-project');
   expect(serviceInfo.Spec.Labels['traefik.backend']).toEqual(`${name}.test`);
+  expect(serviceInfo.Spec.Labels['traefik.docker.network']).toEqual(mockConfig.exoframeNetworkSwarm);
+  expect(serviceInfo.Spec.Labels['traefik.enable']).toEqual('true');
   expect(serviceInfo.Spec.Networks.length).toEqual(1);
   expect(serviceInfo.Spec.Networks[0].Aliases.includes('test')).toBeTruthy();
   expect(serviceInfo.Spec.TaskTemplate.RestartPolicy).toMatchObject({Condition: 'none', MaxAttempts: 1});
@@ -148,6 +153,8 @@ test('Should deploy simple node project to swarm', async done => {
   expect(serviceInfo.Spec.Labels['exoframe.user']).toEqual('admin');
   expect(serviceInfo.Spec.Labels['exoframe.project']).toEqual(name.replace(`-${deployId}`, ''));
   expect(serviceInfo.Spec.Labels['traefik.backend']).toEqual('localhost');
+  expect(serviceInfo.Spec.Labels['traefik.docker.network']).toEqual(mockConfig.exoframeNetworkSwarm);
+  expect(serviceInfo.Spec.Labels['traefik.enable']).toEqual('true');
   expect(serviceInfo.Spec.Labels['traefik.frontend.rule']).toEqual('Host:localhost');
   expect(serviceInfo.Spec.Networks.length).toEqual(1);
 
@@ -189,6 +196,8 @@ test('Should deploy simple HTML project to swarm', async done => {
   expect(serviceInfo.Spec.Labels['exoframe.user']).toEqual('admin');
   expect(serviceInfo.Spec.Labels['exoframe.project']).toEqual('simple-html');
   expect(serviceInfo.Spec.Labels['traefik.backend']).toEqual(name);
+  expect(serviceInfo.Spec.Labels['traefik.docker.network']).toEqual(mockConfig.exoframeNetworkSwarm);
+  expect(serviceInfo.Spec.Labels['traefik.enable']).toEqual('true');
   expect(serviceInfo.Spec.Labels['traefik.frontend.rule']).toBeUndefined();
   expect(serviceInfo.Spec.Networks.length).toEqual(1);
 
@@ -228,6 +237,8 @@ test('Should update simple HTML project in swarm', async done => {
   expect(serviceInfo.ID).toEqual(simpleHtmlInitialDeploy);
   expect(serviceInfo.Spec.Labels['exoframe.user']).toEqual('admin');
   expect(serviceInfo.Spec.Labels['exoframe.project']).toEqual('simple-html');
+  expect(serviceInfo.Spec.Labels['traefik.docker.network']).toEqual(mockConfig.exoframeNetworkSwarm);
+  expect(serviceInfo.Spec.Labels['traefik.enable']).toEqual('true');
   expect(serviceInfo.Spec.Labels['traefik.frontend.rule']).toBeUndefined();
   expect(serviceInfo.Spec.Networks.length).toEqual(1);
 
@@ -278,6 +289,10 @@ test('Should deploy simple compose project to swarm', async done => {
   expect(serviceTwo.Spec.Labels['exoframe.project']).toEqual(nameTwo.replace('_redis', ''));
   expect(serviceOne.Spec.Labels['traefik.backend']).toEqual(nameOne.replace('_web', '-web'));
   expect(serviceTwo.Spec.Labels['traefik.backend']).toEqual(nameTwo.replace('_redis', '-redis'));
+  expect(serviceOne.Spec.Labels['traefik.docker.network']).toEqual(mockConfig.exoframeNetworkSwarm);
+  expect(serviceTwo.Spec.Labels['traefik.docker.network']).toEqual(mockConfig.exoframeNetworkSwarm);
+  expect(serviceOne.Spec.Labels['traefik.enable']).toEqual('true');
+  expect(serviceTwo.Spec.Labels['traefik.enable']).toEqual('true');
   expect(serviceOne.Spec.Labels['traefik.frontend.rule']).toEqual('Host:test.dev');
   expect(serviceOne.Spec.TaskTemplate.Networks.length).toEqual(2);
   expect(serviceTwo.Spec.TaskTemplate.Networks.length).toEqual(2);
@@ -330,6 +345,10 @@ test('Should update simple compose project in swarm', async done => {
   expect(serviceTwo.Spec.Labels['exoframe.project']).toEqual(nameTwo.replace('_redis', ''));
   expect(serviceOne.Spec.Labels['traefik.backend']).toEqual(nameOne.replace('_web', '-web'));
   expect(serviceTwo.Spec.Labels['traefik.backend']).toEqual(nameTwo.replace('_redis', '-redis'));
+  expect(serviceOne.Spec.Labels['traefik.docker.network']).toEqual(mockConfig.exoframeNetworkSwarm);
+  expect(serviceTwo.Spec.Labels['traefik.docker.network']).toEqual(mockConfig.exoframeNetworkSwarm);
+  expect(serviceOne.Spec.Labels['traefik.enable']).toEqual('true');
+  expect(serviceTwo.Spec.Labels['traefik.enable']).toEqual('true');
   expect(serviceOne.Spec.Labels['traefik.frontend.rule']).toEqual('Host:test.dev');
   expect(serviceOne.Spec.TaskTemplate.Networks.length).toEqual(2);
   expect(serviceTwo.Spec.TaskTemplate.Networks.length).toEqual(2);
@@ -489,6 +508,8 @@ test('Should deploy project with configured template to swarm', async done => {
   expect(serviceInfo.Spec.Labels['exoframe.user']).toEqual('admin');
   expect(serviceInfo.Spec.Labels['exoframe.project']).toEqual(name.replace(`-${deployId}`, ''));
   expect(serviceInfo.Spec.Labels['traefik.backend']).toEqual('localhost');
+  expect(serviceInfo.Spec.Labels['traefik.docker.network']).toEqual(mockConfig.exoframeNetworkSwarm);
+  expect(serviceInfo.Spec.Labels['traefik.enable']).toEqual('true');
   expect(serviceInfo.Spec.Labels['traefik.frontend.rule']).toEqual('Host:localhost');
   expect(serviceInfo.Spec.Networks.length).toEqual(1);
 

--- a/test/deploy.test.js
+++ b/test/deploy.test.js
@@ -89,6 +89,8 @@ test('Should deploy simple docker project', async done => {
   expect(containerInfo.Labels['exoframe.user']).toEqual('admin');
   expect(containerInfo.Labels['exoframe.project']).toEqual('test-project');
   expect(containerInfo.Labels['traefik.backend']).toEqual(`${name}.test`);
+  expect(containerInfo.Labels['traefik.docker.network']).toEqual('exoframe');
+  expect(containerInfo.Labels['traefik.enable']).toEqual('true');
   expect(containerInfo.NetworkSettings.Networks.exoframe).toBeDefined();
 
   const containerData = docker.getContainer(containerInfo.Id);
@@ -138,6 +140,8 @@ test('Should deploy simple node project', async done => {
   expect(container.Labels['exoframe.user']).toEqual('admin');
   expect(container.Labels['exoframe.project']).toEqual(name.replace(`-${deployId}`, ''));
   expect(container.Labels['traefik.backend']).toEqual('localhost');
+  expect(container.Labels['traefik.docker.network']).toEqual('exoframe');
+  expect(container.Labels['traefik.enable']).toEqual('true');
   expect(container.Labels['traefik.frontend.rule']).toEqual('Host:localhost');
   expect(container.NetworkSettings.Networks.exoframe).toBeDefined();
 
@@ -178,6 +182,8 @@ test('Should deploy simple HTML project', async done => {
   expect(container.Labels['exoframe.user']).toEqual('admin');
   expect(container.Labels['exoframe.project']).toEqual('simple-html');
   expect(container.Labels['traefik.backend']).toEqual(name);
+  expect(container.Labels['traefik.docker.network']).toEqual('exoframe');
+  expect(container.Labels['traefik.enable']).toEqual('true');
   expect(container.Labels['traefik.frontend.rule']).toBeUndefined();
   expect(container.NetworkSettings.Networks.exoframe).toBeDefined();
 
@@ -218,6 +224,8 @@ test('Should update simple HTML project', async done => {
   expect(container.Labels['exoframe.user']).toEqual('admin');
   expect(container.Labels['exoframe.project']).toEqual('simple-html');
   expect(container.Labels['traefik.backend']).toEqual(name);
+  expect(container.Labels['traefik.docker.network']).toEqual('exoframe');
+  expect(container.Labels['traefik.enable']).toEqual('true');
   expect(container.Labels['traefik.frontend.rule']).toBeUndefined();
   expect(container.NetworkSettings.Networks.exoframe).toBeDefined();
 
@@ -282,6 +290,10 @@ test('Should deploy simple compose project', async done => {
   expect(containerTwo.Labels['exoframe.project']).toEqual(nameTwo.replace(`-redis-${deployIdTwo}`, ''));
   expect(containerOne.Labels['traefik.backend']).toEqual(nameOne.replace(`-${deployIdOne}`, ''));
   expect(containerTwo.Labels['traefik.backend']).toEqual(nameTwo.replace(`-${deployIdTwo}`, ''));
+  expect(containerOne.Labels['traefik.docker.network']).toEqual('exoframe');
+  expect(containerTwo.Labels['traefik.docker.network']).toEqual('exoframe');
+  expect(containerOne.Labels['traefik.enable']).toEqual('true');
+  expect(containerTwo.Labels['traefik.enable']).toEqual('true');
   expect(containerOne.Labels['traefik.frontend.rule']).toEqual('Host:test.dev');
   expect(containerOne.NetworkSettings.Networks.exoframe).toBeDefined();
   expect(containerTwo.NetworkSettings.Networks.exoframe).toBeDefined();
@@ -340,6 +352,10 @@ test('Should update simple compose project', async done => {
   expect(containerTwo.Labels['exoframe.project']).toEqual(nameTwo.replace(`-redis-${deployIdTwo}`, ''));
   expect(containerOne.Labels['traefik.backend']).toEqual(nameOne.replace(`-${deployIdOne}`, ''));
   expect(containerTwo.Labels['traefik.backend']).toEqual(nameTwo.replace(`-${deployIdTwo}`, ''));
+  expect(containerOne.Labels['traefik.docker.network']).toEqual('exoframe');
+  expect(containerTwo.Labels['traefik.docker.network']).toEqual('exoframe');
+  expect(containerOne.Labels['traefik.enable']).toEqual('true');
+  expect(containerTwo.Labels['traefik.enable']).toEqual('true');
   expect(containerOne.Labels['traefik.frontend.rule']).toEqual('Host:test.dev');
   expect(containerOne.NetworkSettings.Networks.exoframe).toBeDefined();
   expect(containerTwo.NetworkSettings.Networks.exoframe).toBeDefined();
@@ -495,6 +511,8 @@ test('Should deploy project with configured template', async done => {
   expect(container.Labels['exoframe.user']).toEqual('admin');
   expect(container.Labels['exoframe.project']).toEqual(name.replace(`-${deployId}`, ''));
   expect(container.Labels['traefik.backend']).toEqual('localhost');
+  expect(container.Labels['traefik.docker.network']).toEqual('exoframe');
+  expect(container.Labels['traefik.enable']).toEqual('true');
   expect(container.Labels['traefik.frontend.rule']).toEqual('Host:localhost');
   expect(container.NetworkSettings.Networks.exoframe).toBeDefined();
 


### PR DESCRIPTION
Add `traefik.docker.network` and `traefik.enable` labels to created docker containers