### PR TITLE
Fix bugs related with docker-compose.yml deployments

### DIFF
--- a/src/docker/templates/compose.js
+++ b/src/docker/templates/compose.js
@@ -23,7 +23,11 @@ const updateCompose = ({username, baseName, serverConfig, composePath, util, res
   // read compose file
   const compose = yaml.safeLoad(fs.readFileSync(composePath, 'utf8'));
 
-  if (serverConfig.swarm && compose.version !== '3') {
+  if (
+    serverConfig.swarm
+    && typeof compose.version === 'string'
+    && !compose.version.startsWith('3')
+  ) {
     util.logger.debug('Compose file should be of version 3!');
     util.writeStatus(resultStream, {
       message: 'Running in swarm mode, can only deploy docker-compose file of version 3!',

--- a/src/docker/templates/compose.js
+++ b/src/docker/templates/compose.js
@@ -54,13 +54,15 @@ const updateCompose = ({username, baseName, serverConfig, composePath, util, res
   Object.keys(compose.services).forEach(svcKey => {
     const name = `${baseName}-${svcKey}-${uid.split('-').shift()}`;
     const backend = `${baseName}-${svcKey}`;
+    const networks = Array.from(
+      new Set([network, ...compose.services[svcKey].networks || ['default']])
+    );
     // update basic settings
     const ext = {
       container_name: name,
       restart: 'on-failure:2',
-      networks: [network, 'default'],
     };
-    compose.services[svcKey] = Object.assign({}, ext, compose.services[svcKey]);
+    compose.services[svcKey] = Object.assign({}, ext, compose.services[svcKey], {networks});
 
     // update labels if needed
     const extLabels = {

--- a/src/docker/templates/compose.js
+++ b/src/docker/templates/compose.js
@@ -204,7 +204,7 @@ exports.executeTemplate = async ({username, config, serverConfig, tempDockerDir,
 
   // re-build images if needed
   const {code: buildExitCode, log: buildLog} = await executeCompose({
-    cmd: ['--project-name', defaultProjectPrefix, 'build'],
+    cmd: ['--project-name', baseName, 'build'],
     resultStream,
     tempDockerDir,
     writeStatus: util.writeStatus,
@@ -272,7 +272,7 @@ exports.executeTemplate = async ({username, config, serverConfig, tempDockerDir,
 
   // execute compose 'up -d'
   const exitCode = await executeCompose({
-    cmd: ['--project-name', defaultProjectPrefix, 'up', '-d'],
+    cmd: ['--project-name', baseName, 'up', '-d'],
     resultStream,
     tempDockerDir,
     writeStatus: util.writeStatus,


### PR DESCRIPTION
- fix(compose): allow compose versions >= 3 5fdaa98
- fix(compose): merge networks instead of replacing them ec3e9b0
- fix(compose): use generated project names: using the same project in docker-compose versions > 3.6 and 3.7 causes 'docker-compose up' command to remove all the previous deployments

The change is hard to migrate to, because you essentially need to re-create _all_ deployments with the correct stacks. Previously exoframe used the constant prefix as the project name for *ALL* docker-compose deployments (but this caused v3.6 deployments to automatically remove the previous one!), so now when updating a deployment you might get an error regarding conflicting containers. Not sure what to do about this.