### PR TITLE
Add support for traefik frontend basic auth

### DIFF
--- a/src/docker/start.js
+++ b/src/docker/start.js
@@ -250,6 +250,11 @@ exports.start = async ({image, username, resultStream, existing = []}) => {
     Labels['traefik.frontend.rateLimit.rateSet.exo.burst'] = String(config.rateLimit.burst);
   }
 
+  // if basic auth is set - add it to config
+  if (config.basicAuth && config.basicAuth.length) {
+    Labels['traefik.frontend.auth.basic.users'] = config.basicAuth
+  }
+
   // if running in swarm mode - run traefik as swarm service
   if (serverConfig.swarm) {
     // create service config

--- a/test/deploy.test.js
+++ b/test/deploy.test.js
@@ -189,6 +189,7 @@ test('Should deploy simple HTML project', async done => {
   expect(container.Labels['traefik.frontend.rateLimit.rateSet.exo.average']).toEqual('1');
   expect(container.Labels['traefik.frontend.rateLimit.rateSet.exo.burst']).toEqual('5');
   expect(container.Labels['traefik.frontend.rule']).toBeUndefined();
+  expect(container.Labels['traefik.frontend.auth.basic.users']).toEqual('user:$apr1$$9Cv/OMGj$$ZomWQzuQbL.3TRCS81A1g/');
   expect(container.NetworkSettings.Networks.exoframe).toBeDefined();
 
   // store initial deploy id

--- a/test/fixtures/html-project/exoframe.json
+++ b/test/fixtures/html-project/exoframe.json
@@ -7,5 +7,6 @@
     "period": "1s",
     "average": 1,
     "burst": 5
-  }
+  },
+  "basicAuth": "user:$apr1$$9Cv/OMGj$$ZomWQzuQbL.3TRCS81A1g/"
 }


### PR DESCRIPTION
Added support for frontend basic auth for start function but I am not totally sure how to check for basic auth field under `startFromParams` function and also I noticed that rate limit is also not being parsed there. Any thoughts?