### PR TITLE
Feature: pass Env (including secrets) to docker-compose

### DIFF
--- a/test/__mocks__/util.js
+++ b/test/__mocks__/util.js
@@ -1,8 +1,9 @@
 /* eslint-env jest */
 // mock util module
+const {runYarn, getProjectConfig, ...actualUtil} = jest.requireActual('../../src/util/index.js');
 const util = jest.genMockFromModule('../../src/util/index.js');
 
 util.runYarn = () => new Promise(r => r());
 util.getProjectConfig = folder => folder;
 
-module.exports = util;
+module.exports = {...util, ...actualUtil};

--- a/test/fixtures/compose-project/docker-compose.yml
+++ b/test/fixtures/compose-project/docker-compose.yml
@@ -4,5 +4,7 @@ services:
     build: .
     labels:
       traefik.frontend.rule: 'Host:test.dev'
+      custom.envvar: "${CUSTOM_LABEL}"
+      custom.secret: "${CUSTOM_SECRET}"
   redis:
     image: "redis:alpine"

--- a/test/fixtures/compose-project/exoframe.json
+++ b/test/fixtures/compose-project/exoframe.json
@@ -1,4 +1,8 @@
 {
   "name": "test-compose-deploy",
-  "restart": "no"
+  "restart": "no",
+  "env": {
+    "CUSTOM_LABEL": "custom-value",
+    "CUSTOM_SECRET": "@test-secret"
+  }
 }


### PR DESCRIPTION
This PR contains 2 changes:

- [x] Extracts the getHost and getEnv utilities from docker/start in order to reuse them in compose template.
- [x] Passes the defined Env and resolved secrets to the `docker-compose` context so that they may be freely used in the `docker-compose.yml` file.

Modified the `compose` test to include both cases: one secret and one env var.