### PR TITLE
Fix: traefik mount with rw / ro

### DIFF
--- a/src/docker/traefik.js
+++ b/src/docker/traefik.js
@@ -37,14 +37,9 @@ exports.initTraefik = async exoNet => {
   const server = allContainers.find(c => c.Names.find(n => n.startsWith('/exoframe-server')));
   // if server was found - extract traefik path from it
   if (server) {
-    const serverContainer = docker.getContainer(server.Id);
-    const serverInfo = await serverContainer.inspect();
-    const volumes = serverInfo.HostConfig.Binds;
-    const mountRegex = RegExp(':/root/.exoframe(:rw|:ro)?$');
-    const configVol = (volumes || []).find(v => mountRegex.test(v));
+    const configVol = (server.Mounts || []).find(v => v.Destination === '/root/.exoframe');
     if (configVol) {
-      const configPath = configVol.replace(mountRegex, '');
-      traefikPath = path.join(configPath, 'traefik');
+      traefikPath = path.join(configVol.Source, 'traefik');
       logger.info('Running in docker, using existing volume to mount traefik config:', traefikPath);
       initLocal = false;
     }

--- a/src/docker/traefik.js
+++ b/src/docker/traefik.js
@@ -40,9 +40,10 @@ exports.initTraefik = async exoNet => {
     const serverContainer = docker.getContainer(server.Id);
     const serverInfo = await serverContainer.inspect();
     const volumes = serverInfo.HostConfig.Binds;
-    const configVol = (volumes || []).find(v => v.endsWith(':/root/.exoframe'));
+    const mountRegex = RegExp(':/root/.exoframe(:rw|:ro)?$');
+    const configVol = (volumes || []).find(v => mountRegex.test(v));
     if (configVol) {
-      const configPath = configVol.replace(':/root/.exoframe', '');
+      const configPath = configVol.replace(mountRegex, '');
       traefikPath = path.join(configPath, 'traefik');
       logger.info('Running in docker, using existing volume to mount traefik config:', traefikPath);
       initLocal = false;

--- a/src/logger/index.js
+++ b/src/logger/index.js
@@ -2,7 +2,7 @@ const {Signale} = require('signale');
 
 // prepare level
 const levelTesting = process.env.NODE_ENV === 'testing' ? 'error' : false;
-const level = levelTesting || process.env.NODE_ENV === 'production' ? 'warn' : 'debug';
+const level = levelTesting || (process.env.NODE_ENV === 'production' ? 'warn' : 'debug');
 
 const logger = new Signale({
   scope: 'exoframe-server',

--- a/test/docker/traefik.test.js
+++ b/test/docker/traefik.test.js
@@ -1,0 +1,71 @@
+/* eslint-env jest */
+// mock config for testing
+jest.mock('../../src/config', () => require('../__mocks__/config'));
+
+// npm packages
+const getPort = require('get-port');
+
+// our packages
+const {startServer} = require('../../src');
+const {getConfig, waitForConfig} = require('../../src/config');
+const docker = require('../../src/docker/docker');
+const {initTraefik} = require('../../src/docker/traefik');
+const {initNetwork} = require('../../src/docker/network');
+
+// container vars
+let fastify;
+let config;
+
+beforeAll(async () => {
+  // start server
+  const port = await getPort();
+  fastify = await startServer(port);
+
+  // get config
+  await waitForConfig();
+  config = getConfig();
+
+  return fastify;
+});
+
+afterAll(() => fastify.close());
+
+describe('Traefik', () => {
+  let exoNet;
+  let container;
+
+  beforeAll(async () => {
+    // create exoframe network if needed
+    exoNet = await initNetwork();
+
+    // run traefik init
+    await initTraefik(exoNet);
+
+    // get traefik container
+    const allContainers = await docker.listContainers();
+    container = allContainers.find(c => c.Names.find(n => n === `/${config.traefikName}`));
+  });
+
+  test('Should start traefik container', () => {
+    expect(container).toBeDefined();
+    expect(container.State).toBe('running');
+  });
+
+  test('Should attach traefik to network', () => {
+    expect(container.NetworkSettings.Networks.exoframe).toBeDefined();
+  });
+
+  test('Should open traefik ports', () => {
+    expect(container.Ports.length).toEqual(2);
+    expect(container.Ports.find(p => p.PrivatePort === 443)).toBeTruthy();
+    expect(container.Ports.find(p => p.PublicPort === 443)).toBeTruthy();
+    expect(container.Ports.find(p => p.PrivatePort === 80)).toBeTruthy();
+    expect(container.Ports.find(p => p.PublicPort === 80)).toBeTruthy();
+  });
+
+  test('Should mount config folder to traefik', () => {
+    console.log(container.Mounts);
+    expect(container.Mounts.find(m => m.Destination === '/var/run/docker.sock')).toBeTruthy();
+    expect(container.Mounts.find(m => m.Destination === '/var/traefik')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
I added a more robust regex so if your exoframe-server mount looks like: `/home/anbraten/exoframe-server/data:/root/.exoframe:rw` it would match, so `traefikPath` would be the remaining string after removing `:/root/.exoframe:rw`. 

PS: `:rw` was added, because I tried running the server with docker-compose.