### PR TITLE
WIP: Feature to use custom traefik config

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -91,7 +91,7 @@ const defaultConfig = {
   updateChannel: 'stable',
   traefikImage: 'traefik:latest',
   traefikName: 'exoframe-traefik',
-  traefikArgs: [],
+  traefikDisableGeneratedConfig: false,
   exoframeNetwork: 'exoframe',
   publicKeysPath,
   plugins: {


### PR DESCRIPTION
# Add possibility to adjust traefik settings with config file.

Issue: Supply Traefik config file exoframejs/exoframe#139

## Standard way: 
- exoframe creates `traefik.yml`
- user adds settings to `traefik.yml`
- on next start exoframe merges settings with old / current  `traefik.yml`

## Disabled config generation:
This can be done by setting: `traefikDisableGeneratedConfig: false` in `server.config.yml`
- exoframe start traefik, but does not touch `traefik.yml`

## TODO / Current problems
- [x] exoframe specific config like `letsencrypt` will not be removed after being once added
- [ ] update docs
- [x] wont be possibile to use toml config (doesn't sound like a real problem to me)