### PR TITLE
fix: docker compose build

### DIFF
--- a/src/docker/templates/compose.js
+++ b/src/docker/templates/compose.js
@@ -144,7 +144,7 @@ exports.executeTemplate = async ({
 
   // re-build images if needed
   const {code: buildExitCode, log: buildLog} = await executeCompose({
-    cmd: ['--project-name', baseName, '--force-rm', 'build'],
+    cmd: ['--project-name', baseName, 'build', '--force-rm'],
     env,
     resultStream,
     tempDockerDir,


### PR DESCRIPTION
Fixed docker compose setups from leaving containers after a failed build. 
Should fix current github actions problem.