### PR TITLE
Keep the restart policy after container update

### DIFF
--- a/src/routes/update.js
+++ b/src/routes/update.js
@@ -101,6 +101,7 @@ module.exports = fastify => {
             Labels: oldServerInfo.Config.Labels,
             HostConfig: {
               Binds: oldServerInfo.HostConfig.Binds,
+              RestartPolicy: oldServerInfo.HostConfig.RestartPolicy,
             },
           };
           // start new self


### PR DESCRIPTION
When the exoframe-server container updates itself it starts a new container with the updated image and copies some of the configuration of the current container over.  This change now includes the RestartPolicy, so the updated server behaves the same way in regards to crashes, computer restarts etc.

This closes https://github.com/exoframejs/exoframe/issues/295

Please note that I have not had time to test those changes on my local machine, but I'm pretty confident this should work.