### PR TITLE
Map docker-compose label lists to object notation when supplied

### DIFF
--- a/src/docker/templates/compose.js
+++ b/src/docker/templates/compose.js
@@ -11,6 +11,18 @@ const {getHost, getEnv} = require('../../util');
 const generateBaseName = ({username, config}) =>
   `exo-${_.kebabCase(username)}-${_.kebabCase(config.name.split(':').shift())}`;
 
+// maps array labels to objects, if necessary
+const asObjectLabels = labels =>
+  !Array.isArray(labels)
+    ? labels
+    : labels.reduce((acc, label) => {
+        // Split at =, but only retain first value
+        const [name, ...values] = label.split('=');
+        const value = values.join('=');
+
+        return {...acc, [name]: value};
+      }, {});
+
 // function to update compose file with required vars
 const updateCompose = ({username, baseName, serverConfig, composePath}) => {
   const uid = uuidv1();
@@ -51,7 +63,7 @@ const updateCompose = ({username, baseName, serverConfig, composePath}) => {
       'traefik.enable': 'true',
     };
 
-    compose.services[svcKey].labels = Object.assign({}, extLabels, compose.services[svcKey].labels);
+    compose.services[svcKey].labels = Object.assign({}, extLabels, asObjectLabels(compose.services[svcKey].labels));
   });
 
   // write new compose back to file

--- a/test/deploy.test.js
+++ b/test/deploy.test.js
@@ -440,6 +440,8 @@ test('Should deploy simple compose project', async done => {
   expect(containerOne.Labels[`traefik.http.routers.web.rule`]).toEqual('Host(`test.dev`)');
   expect(containerOne.Labels['custom.envvar']).toEqual('custom-value');
   expect(containerOne.Labels['custom.secret']).toEqual('custom-secret-value');
+  expect(containerTwo.Labels.username).toEqual('user1234');
+  expect(containerTwo.Labels.password).toEqual('abcde=cddfd=gdfg');
   expect(containerOne.NetworkSettings.Networks.exoframe).toBeDefined();
   expect(containerTwo.NetworkSettings.Networks.exoframe).toBeDefined();
 
@@ -496,6 +498,8 @@ test('Should update simple compose project', async done => {
   expect(containerOne.Labels[`traefik.http.routers.web.rule`]).toEqual('Host(`test.dev`)');
   expect(containerOne.Labels['custom.envvar']).toEqual('custom-value');
   expect(containerOne.Labels['custom.secret']).toEqual('custom-secret-value');
+  expect(containerTwo.Labels.username).toEqual('user1234');
+  expect(containerTwo.Labels.password).toEqual('abcde=cddfd=gdfg');
   expect(containerOne.NetworkSettings.Networks.exoframe).toBeDefined();
   expect(containerTwo.NetworkSettings.Networks.exoframe).toBeDefined();
 

--- a/test/fixtures/compose-project/docker-compose.yml
+++ b/test/fixtures/compose-project/docker-compose.yml
@@ -8,3 +8,6 @@ services:
       custom.secret: '${CUSTOM_SECRET}'
   redis:
     image: 'redis:alpine'
+    labels:
+      - username=user1234
+      - "password=abcde=cddfd=gdfg"


### PR DESCRIPTION
Allows usage of list/array labels in docker compose yaml.

Closes https://github.com/exoframejs/exoframe/issues/297
