### PR TITLE
docker image prune -a

### DIFF
--- a/src/docker/util.js
+++ b/src/docker/util.js
@@ -38,7 +38,7 @@ exports.pruneDocker = async () => {
   // TODO: re-enable pruneBuilder once fixed in dockerode
   // await docker.pruneBuilder();
   logger.debug('Running prune..');
-  const result = await Promise.all([docker.pruneImages({ filters : { dangling : { 'false' : true } } }), docker.pruneVolumes()]);
+  const result = await Promise.all([docker.pruneImages(filters: {dangling: {false: true}}), docker.pruneVolumes()]);
   logger.debug('Prune done:', result);
   return result;
 };

--- a/src/docker/util.js
+++ b/src/docker/util.js
@@ -38,7 +38,7 @@ exports.pruneDocker = async () => {
   // TODO: re-enable pruneBuilder once fixed in dockerode
   // await docker.pruneBuilder();
   logger.debug('Running prune..');
-  const result = await Promise.all([docker.pruneImages(filters: {dangling: {false: true}}), docker.pruneVolumes()]);
+  const result = await Promise.all([docker.pruneImages({filters: {dangling: {false: true}}}), docker.pruneVolumes()]);
   logger.debug('Prune done:', result);
   return result;
 };

--- a/src/docker/util.js
+++ b/src/docker/util.js
@@ -38,7 +38,7 @@ exports.pruneDocker = async () => {
   // TODO: re-enable pruneBuilder once fixed in dockerode
   // await docker.pruneBuilder();
   logger.debug('Running prune..');
-  const result = await Promise.all([docker.pruneImages(), docker.pruneVolumes()]);
+  const result = await Promise.all([docker.pruneImages({ filters : { dangling : { 'false' : true } } }), docker.pruneVolumes()]);
   logger.debug('Prune done:', result);
   return result;
 };


### PR DESCRIPTION
I would like to reclaim more space. In my case it was like 4GB after couple month of daily deploys
More info https://github.com/apocas/dockerode/issues/429

`docker system df`
```
TYPE                TOTAL               ACTIVE              SIZE                RECLAIMABLE
Images              18                  6                   5.501GB             4.639GB (84%)
Containers          6                   6                   64.72MB             0B (0%)
Local Volumes       3                   3                   50.92MB             0B (0%)
Build Cache         0                   0                   0B                  0B
```
And after pruning with flag -a
```
TYPE                TOTAL               ACTIVE              SIZE                RECLAIMABLE
Images              6                   6                   1.587GB             0B (0%)
Containers          6                   6                   64.72MB             0B (0%)
Local Volumes       3                   3                   50.92MB             0B (0%)
Build Cache         0                   0                   0B                  0B
```
